### PR TITLE
fix naming

### DIFF
--- a/docs/en/installing/install-mesh.mdx
+++ b/docs/en/installing/install-mesh.mdx
@@ -30,7 +30,7 @@ The Operator might create additional `IstioRevision` instances, when the `Istio`
 
 **Prerequisites**
 
-- The Alauda Service Mesh v2 Operator must be uploaded.
+- The Alauda Service Mesh v2 must be uploaded.
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
 
 **Procedure**

--- a/docs/en/updating/update-mesh/istio-cni.mdx
+++ b/docs/en/updating/update-mesh/istio-cni.mdx
@@ -16,7 +16,7 @@ To update the CNI plugin, modify the `spec.version` field with the target versio
 
 ## Updating the Istio CNI resource version
 
-You can update the Istio CNI resource version by changing the version in the resource. Then, the Service Mesh Operator deploys a new version of the CNI plugin that replaces the old version of the CNI plugin. The `istio-cni-node` pods automatically reconnect to the new CNI plugin.
+You can update the Istio CNI resource version by changing the version in the resource. Then, the Service Mesh v2 Operator deploys a new version of the CNI plugin that replaces the old version of the CNI plugin. The `istio-cni-node` pods automatically reconnect to the new CNI plugin.
 
 **Prerequisites**
 

--- a/docs/en/updating/update-mesh/update-inplace.mdx
+++ b/docs/en/updating/update-mesh/update-inplace.mdx
@@ -127,7 +127,7 @@ When updating Istio using the `InPlace` strategy, you can increment the version 
        type: InPlace
    ```
 
-   The Service Mesh Operator deploys a new version of the control plane that replaces the old version of the control plane. The sidecars automatically reconnect to the new control plane.
+   The Service Mesh v2 Operator deploys a new version of the control plane that replaces the old version of the control plane. The sidecars automatically reconnect to the new control plane.
 
 2. Confirm that the new version of the control plane is ready by running the following command:
 

--- a/docs/en/updating/update-mesh/update-revisionbased.mdx
+++ b/docs/en/updating/update-mesh/update-revisionbased.mdx
@@ -85,7 +85,7 @@ You can use the following section to understand the update process. You can skip
 
 ## Updating Istio control plane with RevisionBased strategy
 
-When updating Istio using the `RevisionBased` strategy, you can upgrade by more than one minor version at a time. The Alauda Service Mesh Operator creates a new `IstioRevision` resource for each change to the `.spec.version` field and deploys a corresponding control plane instance. To migrate workloads to the new control plane, set the `istio.io/rev` label on the namespace to match the name of the `IstioRevision` resource, and then restart the workloads.
+When updating Istio using the `RevisionBased` strategy, you can upgrade by more than one minor version at a time. The Alauda Service Mesh v2 Operator creates a new `IstioRevision` resource for each change to the `.spec.version` field and deploys a corresponding control plane instance. To migrate workloads to the new control plane, set the `istio.io/rev` label on the namespace to match the name of the `IstioRevision` resource, and then restart the workloads.
 
 **Prerequisites**
 
@@ -115,7 +115,7 @@ When updating Istio using the `RevisionBased` strategy, you can upgrade by more 
        type: RevisionBased
    ```
 
-   The Service Mesh Operator deploys a new version of the control plane alongside the old version of the control plane. The sidecars remain connected to the old control plane.
+   The Service Mesh v2 Operator deploys a new version of the control plane alongside the old version of the control plane. The sidecars remain connected to the old control plane.
 
 2. Confirm that both `Istio` and `IstioRevision` resources are ready with the new revision.
 
@@ -213,6 +213,6 @@ When updating Istio using the `RevisionBased` strategy, you can upgrade by more 
       kubectl get istiorevision
       ```
 
-The Alauda Service Mesh Operator deletes the old `IstioRevision` resource and the associated control plane after the grace period defined in the `spec.updateStrategy.inactiveRevisionDeletionGracePeriodSeconds` field expires. The default grace period is `30` seconds.
+The Alauda Service Mesh v2 Operator deletes the old `IstioRevision` resource and the associated control plane after the grace period defined in the `spec.updateStrategy.inactiveRevisionDeletionGracePeriodSeconds` field expires. The default grace period is `30` seconds.
 
 You can increase the grace period to allow sufficient time to test the new control plane before removing the previous revision. Set a higher value during canary upgrades to ensure workload stability before fully transitioning.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated references to "Alauda Service Mesh v2 Operator" for clearer and more consistent naming across installation and update guides. No procedural or instructional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->