### PR TITLE
mark multus and istio cni as required

### DIFF
--- a/docs/en/installing/install-mesh.mdx
+++ b/docs/en/installing/install-mesh.mdx
@@ -7,7 +7,7 @@ weight: 10
 Installing Alauda Service Mesh consists four major parts:
 
 - Installing the Alauda Service Mesh v2 Operator
-- Deploying Istio CNI if required
+- Deploying Istio CNI
 - Deploying Istio control plane
 - Customizing the Istio configuration
 
@@ -32,6 +32,7 @@ The Operator might create additional `IstioRevision` instances, when the `Istio`
 
 - The Alauda Service Mesh v2 must be uploaded.
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
+- The Alauda Container Platform Networking for Multus plugin must be installed.
 
 **Procedure**
 
@@ -63,7 +64,7 @@ Installing Alauda Service Mesh v2 also provisions two categories of custom resou
 
 ## About Istio deployment
 
-To deploy Istio, you must create `Istio` resource. For Huawei CCE or environments that prohibit the use of `NET_ADMIN` and `NET_RAW` permissions in business workloads, `IstioCNI` resource is also required.
+To deploy Istio, you must create `Istio` and `IstioCNI` resources.
 
 The `Istio` resource is responsible for deploying and configuring the Istio Control Plane.
 
@@ -87,6 +88,8 @@ The Alauda Service Mesh v2 Operator leverages this resource's configuration to d
 
 - The Alauda Service Mesh v2 Operator must be installed.
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
+- The Alauda Container Platform Networking for Multus plugin must be installed.
+-
 
 **Procedure**
 
@@ -102,13 +105,9 @@ The Alauda Service Mesh v2 Operator leverages this resource's configuration to d
 
 **Verification**
 
-Wait for `.status.state` field of the `Istio` resource to be `Ready`.
+Wait for `.status.state` field of the `Istio` resource to be `Healthy`.
 
 ### Creating the namespace for IstioCNI
-
-:::info
-You can skip this section if Istio CNI is not required for your environments.
-:::
 
 ```bash
 kubectl create namespace istio-cni
@@ -116,17 +115,14 @@ kubectl create namespace istio-cni
 
 ### Creating the IstioCNI resource using web console
 
-:::info
-You can skip this section if Istio CNI is not required for your environments.
-:::
-
 Create an Istio Container Network Interface (CNI) resource, which contains the configuration file for the Istio CNI plugin.
 The Alauda Service Mesh v2 Operator uses this resource's configuration to deploy the CNI pod.
 
 **Prerequisites**
 
-- The Alauda Service Mesh v2 Operator must be installed.
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
+- The Alauda Service Mesh v2 Operator must be installed.
+- The Alauda Container Platform Networking for Multus plugin must be installed.
 
 **Procedure**
 
@@ -138,11 +134,24 @@ The Alauda Service Mesh v2 Operator uses this resource's configuration to deploy
 6. Click **Create**.
 7. Locate and Select **IstioCNI** and then click **Create**.
 8. Select the `istio-cni` from the **Namespace** drop down.
-9. Click **Create**.
+9. Click **YAML** tab.
+10. Add the following YAML snippet to the **YAML** code editor:
+    ```yaml
+    apiVersion: sailoperator.io/v1
+    kind: IstioCNI
+    spec:
+      # Applying the following contents to the yaml code editor:
+      values:
+        provider: multus  # [!code callout]
+    ```
+    <Callouts>
+      1. Indicates that we should use Multus as the CNI provider.
+    </Callouts>
+11. Click **Create**.
 
 **Verification**
 
-Wait for `.status.state` field of the `IstioCNI` resource to be `Ready`.
+Wait for `.status.state` field of the `IstioCNI` resource to be `Healthy`.
 
 ## Customizing Istio configuration
 

--- a/docs/en/installing/multi-cluster/configuration-overview.mdx
+++ b/docs/en/installing/multi-cluster/configuration-overview.mdx
@@ -6,6 +6,7 @@ weight: 10
 
 To configure a multi-cluster topology you must perform the following actions:
 
+- Install the Alauda Container Platform Networking for Multus plugin for each cluster.
 - Install the Alauda Service Mesh Operator for each cluster.
 - Create or have access to root and intermediate certificates for each cluster.
 - Apply the security certificates for each cluster.

--- a/docs/en/installing/multi-cluster/install-multi-primary-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-multi-primary-multi-network.mdx
@@ -26,6 +26,7 @@ The gateway in each cluster must be reachable from the other cluster.
 
 **Prerequisites**
 
+- You have installed the Alauda Container Platform Networking for Multus plugin all of the clusters that comprise the mesh.
 - You have installed the Alauda Service Mesh v2 Operator on all of the clusters that comprise the mesh.
 - You have completed [Creating certificates for a multi-cluster mesh](./configuration-overview.mdx#creating-certificates-for-a-multi-cluster-mesh).
 - You have completed [Applying certificates to a multi-cluster topology](./configuration-overview.mdx#applying-certificates-to-a-multi-network-multi-cluster-mesh).

--- a/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
@@ -28,6 +28,7 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
 
 **Prerequisites**
 
+- You have installed the Alauda Container Platform Networking for Multus plugin all of the clusters that comprise the mesh.
 - You have installed the Alauda Service Mesh v2 Operator on all of the clusters that comprise the mesh.
 - You have completed [Creating certificates for a multi-cluster mesh](./configuration-overview.mdx#creating-certificates-for-a-multi-cluster-mesh).
 - You have completed [Applying certificates to a multi-cluster topology](./configuration-overview.mdx#applying-certificates-to-a-multi-network-multi-cluster-mesh).

--- a/docs/en/updating/update-mesh/update-inplace.mdx
+++ b/docs/en/updating/update-mesh/update-inplace.mdx
@@ -83,7 +83,7 @@ You can use the following section to understand the update process. You can skip
        type: InPlace
    ```
 
-5. *Optional*: Install the Istio CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named default in the `istio-cni` namespace:
+5. Install the Istio CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named default in the `istio-cni` namespace:
 
    ```yaml
    apiVersion: sailoperator.io/v1
@@ -93,6 +93,8 @@ You can use the following section to understand the update process. You can skip
    spec:
      version: v1.24.6
      namespace: istio-cni
+     values:
+       provider: multus
    ```
 
 ## Updating Istio control plane with InPlace strategy
@@ -102,10 +104,11 @@ When updating Istio using the `InPlace` strategy, you can increment the version 
 **Prerequisites**
 
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
+- You have installed the Alauda Container Platform Networking for Multus plugin.
 - You have installed the Alauda Service Mesh v2 Operator, and deployed Istio.
 - You have installed `istioctl` on your local machine.
 - You have configured the Istio control plane to use the `InPlace` update strategy. In this example, the `Istio` resource named `default` is deployed in the `istio-system` namespace.
-- *Optional*: You have installed the Istio CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+- You have installed the Istio CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
 - You have labeled the `bookinfo` namespace to enable sidecar injection.
 - You have application workloads running in the cluster. In this example, the bookinfo application is deployed in the `bookinfo` namespace.
 

--- a/docs/en/updating/update-mesh/update-revisionbased.mdx
+++ b/docs/en/updating/update-mesh/update-revisionbased.mdx
@@ -58,7 +58,7 @@ You can use the following section to understand the update process. You can skip
        type: RevisionBased
    ```
 
-3. *Optional*: Install the Istio CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named default in the `istio-cni` namespace:
+3. Install the Istio CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named default in the `istio-cni` namespace:
 
    ```yaml
    apiVersion: sailoperator.io/v1
@@ -68,6 +68,8 @@ You can use the following section to understand the update process. You can skip
    spec:
      version: v1.24.6
      namespace: istio-cni
+     values:
+       provider: multus
    ```
 
 4. Get the `IstioRevision` name by running the following command:
@@ -91,9 +93,10 @@ When updating Istio using the `RevisionBased` strategy, you can upgrade by more 
 
 - You are logged in to the Alauda Container Platform web console as cluster-admin.
 - You have installed the Alauda Service Mesh v2 Operator, and deployed Istio.
+- You have installed the Alauda Container Platform Networking for Multus plugin.
 - You have installed `istioctl` on your local machine.
 - You have configured the Istio control plane to use the `RevisionBased` update strategy. In this example, the `Istio` resource named `default` is deployed in the `istio-system` namespace.
-- *Optional*: You have installed the Istio CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+- You have installed the Istio CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
 - You have labeled the `bookinfo` namespace to enable sidecar injection.
 - You have application workloads running in the cluster. In this example, the bookinfo application is deployed in the `bookinfo` namespace.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and upgrade guides to require Istio CNI deployment and the Alauda Container Platform Networking for Multus plugin as prerequisites.
  * Enhanced instructions for creating IstioCNI resources, including explicit YAML examples specifying Multus as the provider.
  * Adjusted verification steps to check for a "Healthy" status.
  * Clarified that both Istio and IstioCNI resources must be created.
  * Removed optional language regarding Istio CNI installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->