### PR TITLE
update istio version; adjust kiali docs

### DIFF
--- a/docs/en/about/about/understanding-service-mesh.mdx
+++ b/docs/en/about/about/understanding-service-mesh.mdx
@@ -58,7 +58,7 @@ kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.26.2
+  version: v1.26.3
   namespace: istio-system
   updateStrategy:
     type: InPlace
@@ -139,7 +139,7 @@ kind: IstioCNI
 metadata:
   name: default
 spec:
-  version: v1.26.2
+  version: v1.26.3
   namespace: istio-cni
   values:
     cni:

--- a/docs/en/integration/observability/kiali.mdx
+++ b/docs/en/integration/observability/kiali.mdx
@@ -74,6 +74,7 @@ The following steps show how to integrate the Alauda Build of Kiali with user-wo
   ```bash
   export PLATFORM_URL=$(kubectl -nkube-public get configmap global-info -o jsonpath='{.data.platformURL}')
   export CLUSTER_NAME=$(kubectl -nkube-public get configmap global-info -o jsonpath='{.data.clusterName}')
+  export ALB_CLASS_NAME=$(kubectl -nkube-public get configmap global-info -o jsonpath='{.data.systemAlbIngressClassName}')
 
   export OIDC_ISSUER=$(kubectl -nkube-public get configmap global-info -o jsonpath='{.data.oidcIssuer}')
   export OIDC_CLIENT_ID=$(kubectl -nkube-public get configmap global-info -o jsonpath='{.data.oidcClientID}')
@@ -123,7 +124,7 @@ The following steps show how to integrate the Alauda Build of Kiali with user-wo
       openid:
         api_proxy: ${PLATFORM_URL}/kubernetes/${CLUSTER_NAME}  # [!code callout]
         api_proxy_ca_data: ${PLATFORM_CA}  # [!code callout]
-        insecure_skip_verify_tls: true  # [!code callout]
+        insecure_skip_verify_tls: true
         issuer_uri: ${OIDC_ISSUER}  # [!code callout]
         client_id: ${OIDC_CLIENT_ID}  # [!code callout]
         username_claim: email
@@ -139,7 +140,7 @@ The following steps show how to integrate the Alauda Build of Kiali with user-wo
           memory: "1Gi"
       ingress:
          enabled: true
-         class_name: global-alb2
+         class_name: ${ALB_CLASS_NAME}  # [!code callout]
     external_services:
       prometheus:
         auth:
@@ -154,13 +155,13 @@ The following steps show how to integrate the Alauda Build of Kiali with user-wo
     1. `web_root` is the path under platform url for accessing the Kiali dashboard.
     2. `api_proxy` points to **erebus** to map ACP user tokens to Kubernetes tokens.
     3. `api_proxy_ca_data` is the base64‑encoded CA certificate used by **erebus**.
-    4. `insecure_skip_verify_tls` can be set to `false` when not using a self-signed CA certificate.
     5. `issuer_uri` is the OIDC issuer URL for **dex**.
     6. `client_id` is the OIDC client ID for **dex**.
     7. `replicas` specifies the number of replicas for the Kiali deployment, should be at least `2` in production environments.
-    8. `username` references the monitoring basic‑auth username stored in the `kiali-monitoring-basic-auth` Secret.
-    9. `password` references the monitoring basic‑auth password stored in the `kiali-monitoring-basic-auth` Secret.
-    10. `url` is the monitoring endpoint for Prometheus or VictoriaMetrics.
+    8. `class_name` is the ingress class name for the Kiali ingress.
+    9. `username` references the monitoring basic‑auth username stored in the `kiali-monitoring-basic-auth` Secret.
+    10. `password` references the monitoring basic‑auth password stored in the `kiali-monitoring-basic-auth` Secret.
+    11. `url` is the monitoring endpoint for Prometheus or VictoriaMetrics.
   </Callouts>
 
   ### Apply the configuration, render the manifest with `envsubst`:

--- a/docs/shared/crds/sailoperator.io_istiocnis.yaml
+++ b/docs/shared/crds/sailoperator.io_istiocnis.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: istiocnis.sailoperator.io
 spec:
   group: sailoperator.io
@@ -66,7 +66,7 @@ spec:
           spec:
             default:
               namespace: istio-cni
-              version: v1.26.2
+              version: v1.26.3
             description: IstioCNISpec defines the desired state of IstioCNI
             properties:
               namespace:
@@ -1074,6 +1074,17 @@ spec:
                           The directory path within the cluster node's filesystem where network namespaces are located.
                           Defaults to '/var/run/netns', in minikube/docker/others can be '/var/run/docker/netns'.
                         type: string
+                      daemonSetLabels:
+                        additionalProperties:
+                          type: string
+                        description: Additional labels to apply to the istio-cni DaemonSet.
+                        type: object
+                      env:
+                        additionalProperties:
+                          type: string
+                        description: "Environment variables passed to the CNI container.\n\nExamples:\nenv:\n\n\tENV_VAR_1:
+                          value1\n\tENV_VAR_2: value2"
+                        type: object
                       excludeNamespaces:
                         description: List of namespaces that should be ignored by
                           the CNI plugin.
@@ -1107,6 +1118,11 @@ spec:
                           Additional annotations to apply to the istio-cni Pods.
 
                           Deprecated: Marked as deprecated in pkg/apis/values_types.proto.
+                        type: object
+                      podLabels:
+                        additionalProperties:
+                          type: string
+                        description: Additional labels to apply to the istio-cni Pods.
                         type: object
                       privileged:
                         description: |-
@@ -1437,40 +1453,15 @@ spec:
                     type: object
                 type: object
               version:
-                default: v1.26.2
+                default: v1.26.3
                 description: |-
                   Defines the version of Istio to install.
-                  Must be one of: v1.26-latest, v1.26.2, v1.26.0, v1.25-latest, v1.25.3, v1.25.2, v1.25.1, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3, v1.24.2, v1.24.1, v1.24.0, master, v1.27-alpha.11ce9e0a.
+                  Must be one of: v1.26-latest, v1.26.3, v1.24-latest, v1.24.6.
                 enum:
                 - v1.26-latest
-                - v1.26.2
-                - v1.26.0
-                - v1.25-latest
-                - v1.25.3
-                - v1.25.2
-                - v1.25.1
+                - v1.26.3
                 - v1.24-latest
                 - v1.24.6
-                - v1.24.5
-                - v1.24.4
-                - v1.24.3
-                - v1.24.2
-                - v1.24.1
-                - v1.24.0
-                - v1.23-latest
-                - v1.23.6
-                - v1.23.5
-                - v1.23.4
-                - v1.23.3
-                - v1.23.2
-                - v1.22-latest
-                - v1.22.8
-                - v1.22.7
-                - v1.22.6
-                - v1.22.5
-                - v1.21.6
-                - master
-                - v1.27-alpha.11ce9e0a
                 type: string
             required:
             - namespace
@@ -1528,9 +1519,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/docs/shared/crds/sailoperator.io_istiorevisions.yaml
+++ b/docs/shared/crds/sailoperator.io_istiorevisions.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: istiorevisions.sailoperator.io
 spec:
   group: sailoperator.io
@@ -534,11 +534,23 @@ spec:
                               to cluster local suffix for cross cluster communication.
                             type: boolean
                         type: object
+                      nativeNftables:
+                        description: Specifies whether native nftables rules should
+                          be used instead of iptables rules for traffic redirection.
+                        type: boolean
                       network:
                         description: |-
                           Network defines the network this cluster belong to. This name
                           corresponds to the networks in the map of mesh networks.
                         type: string
+                      networkPolicy:
+                        description: Settings related to Kubernetes NetworkPolicy.
+                        properties:
+                          enabled:
+                            description: Controls whether default NetworkPolicy resources
+                              will be created.
+                            type: boolean
+                        type: object
                       omitSidecarInjectorConfigMap:
                         description: |-
                           Controls whether the creation of the sidecar injector ConfigMap should be skipped.
@@ -2516,6 +2528,11 @@ spec:
                         description: Indicates if this cluster/install should consume
                           a "remote" istiod instance,
                         type: boolean
+                      enabledLocalInjectorIstiod:
+                        description: |-
+                          If `true`, indicates that this cluster/install should consume a "local istiod" installation,
+                          local istiod inject sidecars
+                        type: boolean
                       injectionCABundle:
                         description: injector ca bundle
                         type: string
@@ -3352,7 +3369,7 @@ spec:
                               Request IDs.\n\t# As this is the default, this has no
                               effect.\n\trequestId: {}\n\tattemptCount:\n\t  disabled:
                               true\n\n```\n\n# Below shows an example of preserving
-                              the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tperserveHttp1HeaderCase:
+                              the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tpreserveHttp1HeaderCase:
                               true\n\n```\n\nSome headers are enabled by default,
                               and require explicitly disabling. See below for an example
                               of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert:
@@ -3476,6 +3493,25 @@ spec:
                                     description: |-
                                       Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to
                                       true.
+                                    type: boolean
+                                type: object
+                              xForwardedHost:
+                                description: |-
+                                  Controls the `X-Forwarded-Host` header. If enabled, the `X-Forwarded-Host` header is appended
+                                  with the original host when it is rewritten.
+                                  This header is disabled by default.
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                type: object
+                              xForwardedPort:
+                                description: |-
+                                  Controls the `X-Forwarded-Port` header. If enabled, the `X-Forwarded-Port` header is header with the port value
+                                  client used to connect to Envoy. It will be ignored if the “x-forwarded-port“ header has been set by any
+                                  trusted proxy in front of Envoy.
+                                  This header is disabled by default.
+                                properties:
+                                  enabled:
                                     type: boolean
                                 type: object
                             type: object
@@ -5148,6 +5184,37 @@ spec:
                             prometheus:
                               description: Configures a Prometheus metrics provider.
                               type: object
+                            sds:
+                              description: |-
+                                Configures an Extension Provider for SDS. This can be used to
+                                configure an external SDS service to supply secrets for certain Gateways for example.
+                                This is useful for scenarios where the secrets are stored in an external secret store like Vault.
+                                The secret should be configured with sds://provider-name format.
+                              properties:
+                                name:
+                                  description: REQUIRED. Specifies the name of the
+                                    provider. This should be used to configure the
+                                    Gateway SDS.
+                                  type: string
+                                port:
+                                  description: REQUIRED. Specifies the port of the
+                                    service.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    REQUIRED. Specifies the service that implements the  SDS service.
+                                    The format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient
+                                    to unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a
+                                    service defined by the Kubernetes service or ServiceEntry.
+
+                                    Example: "gateway-sds.foo.svc.cluster.local" or "bar/gateway-sds.example.com".
+                                  type: string
+                              required:
+                              - name
+                              - port
+                              - service
+                              type: object
                             skywalking:
                               description: Configures a Apache SkyWalking provider.
                               properties:
@@ -5272,7 +5339,7 @@ spec:
                           - message: At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc
                               zipkin lightstep datadog stackdriver opencensus skywalking
                               opentelemetry prometheus envoyFileAccessLog envoyHttpAls
-                              envoyTcpAls envoyOtelAls] should be set
+                              envoyTcpAls envoyOtelAls sds] should be set
                             rule: (has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0)
                               + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0)
                               + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0)
@@ -5280,7 +5347,7 @@ spec:
                               + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0)
                               + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0)
                               + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0)
-                              <= 1
+                              + (has(self.sds)?1:0) <= 1
                         maxItems: 1000
                         type: array
                       h2UpgradePolicy:
@@ -5644,6 +5711,140 @@ spec:
                           The precise semantics of this processing are documented on each resource
                           type.
                         type: string
+                      serviceScopeConfigs:
+                        description: Scope to be applied to select services.
+                        items:
+                          description: |-
+                            Configuration for ambient mode multicluster service scope. This setting allows mesh administrators
+                            to define the criteria by which the cluster's control plane determines which services in other
+                            clusters in the mesh are treated as global (accessible across multiple clusters) versus local
+                            (restricted to a single cluster). The configuration can be applied to services based on namespace
+                            and/or other matching criteria. This is particularly  useful in multicluster service mesh deployments
+                            to control service visibility and access across clusters. This API is not intended to enforce
+                            security policies. Resources like DestinationRules should be used to enforce authorization policies.
+                            If a service matches a global service scope selector, the service's endpoints will be globally
+                            exposed. If a service is locally scoped, its endpoints will only be exposed to local cluster
+                            services.
+
+                            For example, the following configures the scope of all services with the "istio.io/global" label
+                            in matching namespaces to be available globally:
+
+                            ```yaml
+                            serviceScopeConfigs:
+                              - namespacesSelector:
+                                matchExpressions:
+                              - key: istio.io/global
+                                operator: In
+                                values: [true]
+                                servicesSelector:
+                                matchExpressions:
+                              - key: istio.io/global
+                                operator: Exists
+                                scope: GLOBAL
+
+                            ```
+                          properties:
+                            namespaceSelector:
+                              description: Match expression for namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            scope:
+                              description: Specifics the available scope for matching
+                                services.
+                              enum:
+                              - LOCAL
+                              - GLOBAL
+                              type: string
+                            servicesSelector:
+                              description: Match expression for serivces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       serviceSettings:
                         description: Settings to be applied to select services.
                         items:
@@ -5662,6 +5863,14 @@ spec:
                               - "bar.baz.svc.cluster.local"
 
                             ```
+
+                            When in ambient mode, if ServiceSettings are defined they will be considered in addition to the
+                            ServiceScopeConfigs. If a service is defined by ServiceSetting to be cluster local and matches a
+                            global service scope selector, the service will be considered cluster local. If a service is
+                            considered global by ServiceSettings and does not match a global service scope selector
+                            the serive will be considered local. Local scope takes precedence over global scope. Since
+                            ServiceScopeConfigs is local by default, all services are considered local unless it is considered
+                            global by ServiceSettings AND ServiceScopeConfigs.
                           properties:
                             hosts:
                               description: |-
@@ -7044,6 +7253,11 @@ spec:
                           enabled:
                             description: Indicates if this cluster/install should
                               consume a "remote" istiod instance,
+                            type: boolean
+                          enabledLocalInjectorIstiod:
+                            description: |-
+                              If `true`, indicates that this cluster/install should consume a "local istiod" installation,
+                              local istiod inject sidecars
                             type: boolean
                           injectionCABundle:
                             description: injector ca bundle
@@ -9560,31 +9774,10 @@ spec:
               version:
                 description: |-
                   Defines the version of Istio to install.
-                  Must be one of: v1.26.2, v1.26.0, v1.25.3, v1.25.2, v1.25.1, v1.24.6, v1.24.5, v1.24.4, v1.24.3, v1.24.2, v1.24.1, v1.24.0, v1.27-alpha.11ce9e0a.
+                  Must be one of: v1.26.3, v1.24.6.
                 enum:
-                - v1.26.2
-                - v1.26.0
-                - v1.25.3
-                - v1.25.2
-                - v1.25.1
+                - v1.26.3
                 - v1.24.6
-                - v1.24.5
-                - v1.24.4
-                - v1.24.3
-                - v1.24.2
-                - v1.24.1
-                - v1.24.0
-                - v1.23.6
-                - v1.23.5
-                - v1.23.4
-                - v1.23.3
-                - v1.23.2
-                - v1.22.8
-                - v1.22.7
-                - v1.22.6
-                - v1.22.5
-                - v1.21.6
-                - v1.27-alpha.11ce9e0a
                 type: string
             required:
             - namespace
@@ -9639,7 +9832,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: spec.values.revision must match metadata.name
+        - message: spec.values.revision must match metadata.name or be empty when
+            the name is 'default'
           rule: 'self.metadata.name == ''default'' ? (!has(self.spec.values.revision)
             || size(self.spec.values.revision) == 0) : self.spec.values.revision ==
             self.metadata.name'
@@ -9647,9 +9841,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/docs/shared/crds/sailoperator.io_istiorevisiontags.yaml
+++ b/docs/shared/crds/sailoperator.io_istiorevisiontags.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: istiorevisiontags.sailoperator.io
 spec:
   group: sailoperator.io
@@ -145,9 +145,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/docs/shared/crds/sailoperator.io_istios.yaml
+++ b/docs/shared/crds/sailoperator.io_istios.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: istios.sailoperator.io
 spec:
   group: sailoperator.io
@@ -88,7 +88,7 @@ spec:
               namespace: istio-system
               updateStrategy:
                 type: InPlace
-              version: v1.26.2
+              version: v1.26.3
             description: IstioSpec defines the desired state of Istio
             properties:
               namespace:
@@ -607,11 +607,23 @@ spec:
                               to cluster local suffix for cross cluster communication.
                             type: boolean
                         type: object
+                      nativeNftables:
+                        description: Specifies whether native nftables rules should
+                          be used instead of iptables rules for traffic redirection.
+                        type: boolean
                       network:
                         description: |-
                           Network defines the network this cluster belong to. This name
                           corresponds to the networks in the map of mesh networks.
                         type: string
+                      networkPolicy:
+                        description: Settings related to Kubernetes NetworkPolicy.
+                        properties:
+                          enabled:
+                            description: Controls whether default NetworkPolicy resources
+                              will be created.
+                            type: boolean
+                        type: object
                       omitSidecarInjectorConfigMap:
                         description: |-
                           Controls whether the creation of the sidecar injector ConfigMap should be skipped.
@@ -2589,6 +2601,11 @@ spec:
                         description: Indicates if this cluster/install should consume
                           a "remote" istiod instance,
                         type: boolean
+                      enabledLocalInjectorIstiod:
+                        description: |-
+                          If `true`, indicates that this cluster/install should consume a "local istiod" installation,
+                          local istiod inject sidecars
+                        type: boolean
                       injectionCABundle:
                         description: injector ca bundle
                         type: string
@@ -3425,7 +3442,7 @@ spec:
                               Request IDs.\n\t# As this is the default, this has no
                               effect.\n\trequestId: {}\n\tattemptCount:\n\t  disabled:
                               true\n\n```\n\n# Below shows an example of preserving
-                              the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tperserveHttp1HeaderCase:
+                              the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tpreserveHttp1HeaderCase:
                               true\n\n```\n\nSome headers are enabled by default,
                               and require explicitly disabling. See below for an example
                               of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert:
@@ -3549,6 +3566,25 @@ spec:
                                     description: |-
                                       Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to
                                       true.
+                                    type: boolean
+                                type: object
+                              xForwardedHost:
+                                description: |-
+                                  Controls the `X-Forwarded-Host` header. If enabled, the `X-Forwarded-Host` header is appended
+                                  with the original host when it is rewritten.
+                                  This header is disabled by default.
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                type: object
+                              xForwardedPort:
+                                description: |-
+                                  Controls the `X-Forwarded-Port` header. If enabled, the `X-Forwarded-Port` header is header with the port value
+                                  client used to connect to Envoy. It will be ignored if the “x-forwarded-port“ header has been set by any
+                                  trusted proxy in front of Envoy.
+                                  This header is disabled by default.
+                                properties:
+                                  enabled:
                                     type: boolean
                                 type: object
                             type: object
@@ -5221,6 +5257,37 @@ spec:
                             prometheus:
                               description: Configures a Prometheus metrics provider.
                               type: object
+                            sds:
+                              description: |-
+                                Configures an Extension Provider for SDS. This can be used to
+                                configure an external SDS service to supply secrets for certain Gateways for example.
+                                This is useful for scenarios where the secrets are stored in an external secret store like Vault.
+                                The secret should be configured with sds://provider-name format.
+                              properties:
+                                name:
+                                  description: REQUIRED. Specifies the name of the
+                                    provider. This should be used to configure the
+                                    Gateway SDS.
+                                  type: string
+                                port:
+                                  description: REQUIRED. Specifies the port of the
+                                    service.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    REQUIRED. Specifies the service that implements the  SDS service.
+                                    The format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient
+                                    to unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a
+                                    service defined by the Kubernetes service or ServiceEntry.
+
+                                    Example: "gateway-sds.foo.svc.cluster.local" or "bar/gateway-sds.example.com".
+                                  type: string
+                              required:
+                              - name
+                              - port
+                              - service
+                              type: object
                             skywalking:
                               description: Configures a Apache SkyWalking provider.
                               properties:
@@ -5345,7 +5412,7 @@ spec:
                           - message: At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc
                               zipkin lightstep datadog stackdriver opencensus skywalking
                               opentelemetry prometheus envoyFileAccessLog envoyHttpAls
-                              envoyTcpAls envoyOtelAls] should be set
+                              envoyTcpAls envoyOtelAls sds] should be set
                             rule: (has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0)
                               + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0)
                               + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0)
@@ -5353,7 +5420,7 @@ spec:
                               + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0)
                               + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0)
                               + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0)
-                              <= 1
+                              + (has(self.sds)?1:0) <= 1
                         maxItems: 1000
                         type: array
                       h2UpgradePolicy:
@@ -5717,6 +5784,140 @@ spec:
                           The precise semantics of this processing are documented on each resource
                           type.
                         type: string
+                      serviceScopeConfigs:
+                        description: Scope to be applied to select services.
+                        items:
+                          description: |-
+                            Configuration for ambient mode multicluster service scope. This setting allows mesh administrators
+                            to define the criteria by which the cluster's control plane determines which services in other
+                            clusters in the mesh are treated as global (accessible across multiple clusters) versus local
+                            (restricted to a single cluster). The configuration can be applied to services based on namespace
+                            and/or other matching criteria. This is particularly  useful in multicluster service mesh deployments
+                            to control service visibility and access across clusters. This API is not intended to enforce
+                            security policies. Resources like DestinationRules should be used to enforce authorization policies.
+                            If a service matches a global service scope selector, the service's endpoints will be globally
+                            exposed. If a service is locally scoped, its endpoints will only be exposed to local cluster
+                            services.
+
+                            For example, the following configures the scope of all services with the "istio.io/global" label
+                            in matching namespaces to be available globally:
+
+                            ```yaml
+                            serviceScopeConfigs:
+                              - namespacesSelector:
+                                matchExpressions:
+                              - key: istio.io/global
+                                operator: In
+                                values: [true]
+                                servicesSelector:
+                                matchExpressions:
+                              - key: istio.io/global
+                                operator: Exists
+                                scope: GLOBAL
+
+                            ```
+                          properties:
+                            namespaceSelector:
+                              description: Match expression for namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            scope:
+                              description: Specifics the available scope for matching
+                                services.
+                              enum:
+                              - LOCAL
+                              - GLOBAL
+                              type: string
+                            servicesSelector:
+                              description: Match expression for serivces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       serviceSettings:
                         description: Settings to be applied to select services.
                         items:
@@ -5735,6 +5936,14 @@ spec:
                               - "bar.baz.svc.cluster.local"
 
                             ```
+
+                            When in ambient mode, if ServiceSettings are defined they will be considered in addition to the
+                            ServiceScopeConfigs. If a service is defined by ServiceSetting to be cluster local and matches a
+                            global service scope selector, the service will be considered cluster local. If a service is
+                            considered global by ServiceSettings and does not match a global service scope selector
+                            the serive will be considered local. Local scope takes precedence over global scope. Since
+                            ServiceScopeConfigs is local by default, all services are considered local unless it is considered
+                            global by ServiceSettings AND ServiceScopeConfigs.
                           properties:
                             hosts:
                               description: |-
@@ -7117,6 +7326,11 @@ spec:
                           enabled:
                             description: Indicates if this cluster/install should
                               consume a "remote" istiod instance,
+                            type: boolean
+                          enabledLocalInjectorIstiod:
+                            description: |-
+                              If `true`, indicates that this cluster/install should consume a "local istiod" installation,
+                              local istiod inject sidecars
                             type: boolean
                           injectionCABundle:
                             description: injector ca bundle
@@ -9631,40 +9845,15 @@ spec:
                     type: object
                 type: object
               version:
-                default: v1.26.2
+                default: v1.26.3
                 description: |-
                   Defines the version of Istio to install.
-                  Must be one of: v1.26-latest, v1.26.2, v1.26.0, v1.25-latest, v1.25.3, v1.25.2, v1.25.1, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3, v1.24.2, v1.24.1, v1.24.0, master, v1.27-alpha.11ce9e0a.
+                  Must be one of: v1.26-latest, v1.26.3, v1.24-latest, v1.24.6.
                 enum:
                 - v1.26-latest
-                - v1.26.2
-                - v1.26.0
-                - v1.25-latest
-                - v1.25.3
-                - v1.25.2
-                - v1.25.1
+                - v1.26.3
                 - v1.24-latest
                 - v1.24.6
-                - v1.24.5
-                - v1.24.4
-                - v1.24.3
-                - v1.24.2
-                - v1.24.1
-                - v1.24.0
-                - v1.23-latest
-                - v1.23.6
-                - v1.23.5
-                - v1.23.4
-                - v1.23.3
-                - v1.23.2
-                - v1.22-latest
-                - v1.22.8
-                - v1.22.7
-                - v1.22.6
-                - v1.22.5
-                - v1.21.6
-                - master
-                - v1.27-alpha.11ce9e0a
                 type: string
             required:
             - namespace
@@ -9747,9 +9936,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/docs/shared/crds/sailoperator.io_ztunnels.yaml
+++ b/docs/shared/crds/sailoperator.io_ztunnels.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  creationTimestamp: null
   name: ztunnels.sailoperator.io
 spec:
   group: sailoperator.io
@@ -67,7 +67,7 @@ spec:
             default:
               namespace: ztunnel
               profile: ambient
-              version: v1.26.2
+              version: v1.26.3
             description: ZTunnelSpec defines the desired state of ZTunnel
             properties:
               namespace:
@@ -1119,7 +1119,7 @@ spec:
                                   Request IDs.\n\t# As this is the default, this has
                                   no effect.\n\trequestId: {}\n\tattemptCount:\n\t
                                   \ disabled: true\n\n```\n\n# Below shows an example
-                                  of preserving the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tperserveHttp1HeaderCase:
+                                  of preserving the header case for HTTP 1.x requests\n\n```yaml\nproxyHeaders:\n\n\tpreserveHttp1HeaderCase:
                                   true\n\n```\n\nSome headers are enabled by default,
                                   and require explicitly disabling. See below for
                                   an example of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert:
@@ -1244,6 +1244,25 @@ spec:
                                         description: |-
                                           Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to
                                           true.
+                                        type: boolean
+                                    type: object
+                                  xForwardedHost:
+                                    description: |-
+                                      Controls the `X-Forwarded-Host` header. If enabled, the `X-Forwarded-Host` header is appended
+                                      with the original host when it is rewritten.
+                                      This header is disabled by default.
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                    type: object
+                                  xForwardedPort:
+                                    description: |-
+                                      Controls the `X-Forwarded-Port` header. If enabled, the `X-Forwarded-Port` header is header with the port value
+                                      client used to connect to Envoy. It will be ignored if the “x-forwarded-port“ header has been set by any
+                                      trusted proxy in front of Envoy.
+                                      This header is disabled by default.
+                                    properties:
+                                      enabled:
                                         type: boolean
                                     type: object
                                 type: object
@@ -2933,6 +2952,37 @@ spec:
                                 prometheus:
                                   description: Configures a Prometheus metrics provider.
                                   type: object
+                                sds:
+                                  description: |-
+                                    Configures an Extension Provider for SDS. This can be used to
+                                    configure an external SDS service to supply secrets for certain Gateways for example.
+                                    This is useful for scenarios where the secrets are stored in an external secret store like Vault.
+                                    The secret should be configured with sds://provider-name format.
+                                  properties:
+                                    name:
+                                      description: REQUIRED. Specifies the name of
+                                        the provider. This should be used to configure
+                                        the Gateway SDS.
+                                      type: string
+                                    port:
+                                      description: REQUIRED. Specifies the port of
+                                        the service.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        REQUIRED. Specifies the service that implements the  SDS service.
+                                        The format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient
+                                        to unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a
+                                        service defined by the Kubernetes service or ServiceEntry.
+
+                                        Example: "gateway-sds.foo.svc.cluster.local" or "bar/gateway-sds.example.com".
+                                      type: string
+                                  required:
+                                  - name
+                                  - port
+                                  - service
+                                  type: object
                                 skywalking:
                                   description: Configures a Apache SkyWalking provider.
                                   properties:
@@ -3057,8 +3107,8 @@ spec:
                               - message: At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc
                                   zipkin lightstep datadog stackdriver opencensus
                                   skywalking opentelemetry prometheus envoyFileAccessLog
-                                  envoyHttpAls envoyTcpAls envoyOtelAls] should be
-                                  set
+                                  envoyHttpAls envoyTcpAls envoyOtelAls sds] should
+                                  be set
                                 rule: (has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0)
                                   + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0)
                                   + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0)
@@ -3066,7 +3116,7 @@ spec:
                                   + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0)
                                   + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0)
                                   + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0)
-                                  <= 1
+                                  + (has(self.sds)?1:0) <= 1
                             maxItems: 1000
                             type: array
                           h2UpgradePolicy:
@@ -3432,6 +3482,142 @@ spec:
                               The precise semantics of this processing are documented on each resource
                               type.
                             type: string
+                          serviceScopeConfigs:
+                            description: Scope to be applied to select services.
+                            items:
+                              description: |-
+                                Configuration for ambient mode multicluster service scope. This setting allows mesh administrators
+                                to define the criteria by which the cluster's control plane determines which services in other
+                                clusters in the mesh are treated as global (accessible across multiple clusters) versus local
+                                (restricted to a single cluster). The configuration can be applied to services based on namespace
+                                and/or other matching criteria. This is particularly  useful in multicluster service mesh deployments
+                                to control service visibility and access across clusters. This API is not intended to enforce
+                                security policies. Resources like DestinationRules should be used to enforce authorization policies.
+                                If a service matches a global service scope selector, the service's endpoints will be globally
+                                exposed. If a service is locally scoped, its endpoints will only be exposed to local cluster
+                                services.
+
+                                For example, the following configures the scope of all services with the "istio.io/global" label
+                                in matching namespaces to be available globally:
+
+                                ```yaml
+                                serviceScopeConfigs:
+                                  - namespacesSelector:
+                                    matchExpressions:
+                                  - key: istio.io/global
+                                    operator: In
+                                    values: [true]
+                                    servicesSelector:
+                                    matchExpressions:
+                                  - key: istio.io/global
+                                    operator: Exists
+                                    scope: GLOBAL
+
+                                ```
+                              properties:
+                                namespaceSelector:
+                                  description: Match expression for namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                scope:
+                                  description: Specifics the available scope for matching
+                                    services.
+                                  enum:
+                                  - LOCAL
+                                  - GLOBAL
+                                  type: string
+                                servicesSelector:
+                                  description: Match expression for serivces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
                           serviceSettings:
                             description: Settings to be applied to select services.
                             items:
@@ -3450,6 +3636,14 @@ spec:
                                   - "bar.baz.svc.cluster.local"
 
                                 ```
+
+                                When in ambient mode, if ServiceSettings are defined they will be considered in addition to the
+                                ServiceScopeConfigs. If a service is defined by ServiceSetting to be cluster local and matches a
+                                global service scope selector, the service will be considered cluster local. If a service is
+                                considered global by ServiceSettings and does not match a global service scope selector
+                                the serive will be considered local. Local scope takes precedence over global scope. Since
+                                ServiceScopeConfigs is local by default, all services are considered local unless it is considered
+                                global by ServiceSettings AND ServiceScopeConfigs.
                               properties:
                                 hosts:
                                   description: |-
@@ -5591,28 +5785,15 @@ spec:
                     type: object
                 type: object
               version:
-                default: v1.26.2
+                default: v1.26.3
                 description: |-
                   Defines the version of Istio to install.
-                  Must be one of: v1.26-latest, v1.26.2, v1.26.0, v1.25-latest, v1.25.3, v1.25.2, v1.25.1, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3, v1.24.2, v1.24.1, v1.24.0, master, v1.27-alpha.11ce9e0a.
+                  Must be one of: v1.26-latest, v1.26.3, v1.24-latest, v1.24.6.
                 enum:
                 - v1.26-latest
-                - v1.26.2
-                - v1.26.0
-                - v1.25-latest
-                - v1.25.3
-                - v1.25.2
-                - v1.25.1
+                - v1.26.3
                 - v1.24-latest
                 - v1.24.6
-                - v1.24.5
-                - v1.24.4
-                - v1.24.3
-                - v1.24.2
-                - v1.24.1
-                - v1.24.0
-                - master
-                - v1.27-alpha.11ce9e0a
                 type: string
             required:
             - namespace
@@ -5670,9 +5851,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Istio and Istio CNI version references in documentation and examples to v1.26.3.
  * Revised Kiali integration docs to use a dynamic ingress class name and clarified configuration callouts.

* **New Features**
  * Added support for configuring native nftables, network policies, and local istiod injection in CRDs.
  * Introduced new proxy header controls for X-Forwarded-Host and X-Forwarded-Port.
  * Added support for external SDS extension providers.
  * Enabled advanced multicluster service scoping with serviceScopeConfigs.

* **Bug Fixes**
  * Corrected a typo in proxy header configuration fields.

* **Chores**
  * Cleaned up CRD YAML by removing obsolete metadata and status fields, and streamlined allowed version lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->