### PR TITLE
docs: fix some install errors

### DIFF
--- a/docs/en/gateways/about.mdx
+++ b/docs/en/gateways/about.mdx
@@ -410,7 +410,7 @@ The following procedure applies to both ingress and egress gateway deployments.
    spec:
      selector:
        matchLabels:
-       istio: <gateway_name>
+         istio: <gateway_name>
      template:
        metadata:
          annotations:

--- a/docs/en/installing/multi-cluster/install-multi-primary-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-multi-primary-multi-network.mdx
@@ -85,7 +85,7 @@ The gateway in each cluster must be reachable from the other cluster.
        <summary>Click to expand</summary>
 
        ```bash
-       kubectl --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/aladua-mesh/sail-operator/main/docs/deployment-models/resources/expose-services.yaml
+       kubectl --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/alauda-mesh/sail-operator/main/docs/deployment-models/resources/expose-services.yaml
        ```
      </details>
 

--- a/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
@@ -53,8 +53,9 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
 
   2. Create an `Istio` resource on the **East** cluster by running the following command:
 
-     ```yaml
-     cat <<EOF | kubectl --context "${CTX_CLUSTER1}" apply -f -
+     Save the following `Istio` resource to `istio-external.yaml`:
+
+     ```yaml title="istio-external.yaml"
      apiVersion: sailoperator.io/v1
      kind: Istio
      metadata:
@@ -69,12 +70,17 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
              clusterName: cluster1
            network: network1
            externalIstiod: true  # [!code callout]
-     EOF
      ```
 
      <Callouts>
        1. This enables the control plane installed on the **East** cluster to serve as an external control plane for other remote clusters.
      </Callouts>
+
+     Using `kubectl` to apply the `Istio` resource:
+
+     ```bash
+     envsubst < istio-external.yaml | kubectl --context "${CTX_CLUSTER1}" apply -f -
+     ```
 
   3. Wait for the control plane to return the "Ready" status condition by running the following command:
 

--- a/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
@@ -53,7 +53,7 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
 
   2. Create an `Istio` resource on the **East** cluster by running the following command:
 
-     ```bash
+     ```yaml
      cat <<EOF | kubectl --context "${CTX_CLUSTER1}" apply -f -
      apiVersion: sailoperator.io/v1
      kind: Istio

--- a/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
+++ b/docs/en/installing/multi-cluster/install-primary-remote-multi-network.mdx
@@ -53,9 +53,8 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
 
   2. Create an `Istio` resource on the **East** cluster by running the following command:
 
-     Save the following `Istio` resource to `istio-external.yaml`:
-
-     ```yaml title="istio-external.yaml"
+     ```bash
+     cat <<EOF | kubectl --context "${CTX_CLUSTER1}" apply -f -
      apiVersion: sailoperator.io/v1
      kind: Istio
      metadata:
@@ -70,17 +69,12 @@ Services in `cluster2` will reach the control plane in `cluster1` via the same e
              clusterName: cluster1
            network: network1
            externalIstiod: true  # [!code callout]
+     EOF
      ```
 
      <Callouts>
        1. This enables the control plane installed on the **East** cluster to serve as an external control plane for other remote clusters.
      </Callouts>
-
-     Using `kubectl` to apply the `Istio` resource:
-
-     ```bash
-     kubectl --context "${CTX_CLUSTER1}" apply -f istio-external.yaml
-     ```
 
   3. Wait for the control plane to return the "Ready" status condition by running the following command:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed YAML indentation in the gateway deployment example for clearer readability.
  * Corrected a link path typo in the multi-primary, multi-network guide.
  * Simplified the primary‑remote, multi‑network setup instructions to use an inline manifest substitution approach for applying Istio resources, removing the separate file creation/apply step while preserving the same resource content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->