### PR TITLE
feat: add Lifecycle Policy

### DIFF
--- a/docs/en/about/about/index.mdx
+++ b/docs/en/about/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 20
+weight: 30
 ---
 
 # About

--- a/docs/en/about/lifecycle-policy/alauda-build-of-kiali.mdx
+++ b/docs/en/about/lifecycle-policy/alauda-build-of-kiali.mdx
@@ -1,0 +1,27 @@
+---
+weight: 20
+---
+
+# Alauda Build of Kiali Lifecycle Policy
+
+## Version Lifecycle Timeline
+
+Below is the life cycle schedule for released versions of the `Alauda Build of Kiali` operator:
+
+| Version  | Release Date  | End of Support  |
+| -------- | ------------- | -------------- |
+| v2.11.x  | 2025-08-20    | 2027-02-20     |
+
+## Release Policy
+
+A new version of the `Alauda Build of Kiali` operator is released every 4 months.
+
+## Maintenance Policy
+
+Alauda provides 18 months of maintenance support for each released version of the `Alauda Build of Kiali` operator.
+
+During the maintenance period, Alauda will provide the following services to customers:
+
+1. Track the patch versions and promptly provide patches containing bug fixes and security updates.
+2. Provide security updates that comply with Alauda's security standards.
+3. Assist customers in smoothly upgrading the operator to new versions.

--- a/docs/en/about/lifecycle-policy/alauda-service-mesh.mdx
+++ b/docs/en/about/lifecycle-policy/alauda-service-mesh.mdx
@@ -1,0 +1,27 @@
+---
+weight: 10
+---
+
+# Alauda Service Mesh v2 Lifecycle Policy
+
+## Version Lifecycle Timeline
+
+Below is the life cycle schedule for released versions of the `Alauda Service Mesh v2` operator:
+
+| Version  | Release Date  | End of Support  |
+| -------- | ------------- | -------------- |
+| v2.0.x   | 2025-08-20    | 2027-08-20     |
+
+## Release Policy
+
+A new version of the `Alauda Service Mesh v2` operator is released every 4 months.
+
+## Maintenance Policy
+
+Alauda provides 24 months of maintenance support for each released version of the `Alauda Service Mesh v2` operator.
+
+During the maintenance period, Alauda will provide the following services to customers:
+
+1. Track the patch versions and promptly provide patches containing bug fixes and security updates.
+2. Provide security updates that comply with Alauda's security standards.
+3. Assist customers in smoothly upgrading the operator to new versions.

--- a/docs/en/about/lifecycle-policy/index.mdx
+++ b/docs/en/about/lifecycle-policy/index.mdx
@@ -1,0 +1,9 @@
+---
+weight: 20
+---
+
+# Lifecycle Policy
+
+This documentation provides information about Lifecycle Policy.
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.0.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.0.mdx
@@ -1,0 +1,26 @@
+---
+weight: 10
+---
+
+# Alauda Service Mesh v2.0
+
+Alauda Service Mesh v2.0 is built on the [Istio](https://istio.io/) project and is installed using a new Istio Operator derived from the [Sail Operator](https://github.com/istio-ecosystem/sail-operator) (hosted in the **istio-ecosystem** GitHub organization). The Operator provides an expanded set of custom resource definitions (CRDs) to manage Istio components.
+
+## Supported component versions
+
+- `Istio` version: v1.24.6 and v1.26.3
+- `Kiali operator` version: v2.11.0
+
+## Features
+
+- Provides support for `istioctl`, the Istio command-line tool that offers diagnostic and debugging utilities.
+- Support multi-cluster deployment models:
+    - Multi-primary
+    - Primary-remote
+- Enables canary-style upgrades of the Istio control plane via the Istio revision mechanism.
+- Support for the `IstioRevisionTag` resource — a stable revision tag that acts as an alias for Istio control plane revisions.
+- Includes management for the Istio Container Network Interface through the `IstioCNI` CRD, which handles the CNI daemonset lifecycle.
+- Metrics and tracing integrations
+    - **Monitoring components**: Leverages Prometheus or VictoriaMetrics for metrics collection and Alertmanager for alerting.
+    - **Distributed Tracing Platform**: Provides end-to-end distributed tracing capabilities using components such as Jaeger and OpenTelemetry.
+    - **Alauda Build of Kiali**: Offers visualization and operational insights into the service mesh, including real-time traffic topology, configuration validation, and tracing integration.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Lifecycle Policy section with pages for Alauda Service Mesh v2 and Alauda Build of Kiali, detailing version timelines, 4‑month release cadence, and maintenance durations (24 months for ASM, 18 months for Kiali) plus maintenance services.
  * Introduced a Lifecycle Policy overview page.
  * Updated About section navigation ordering to improve page placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->