### PR TITLE
feat: add dual-stack docs

### DIFF
--- a/docs/en/installing/dual-stack/index.mdx
+++ b/docs/en/installing/dual-stack/index.mdx
@@ -1,0 +1,19 @@
+---
+weight: 600
+---
+
+# Dual-stack Support
+
+Kubernetes supports dual-stack networking as a stable feature starting from [v1.23](https://kubernetes.io/docs/concepts/services-networking/dual-stack/), allowing clusters to handle both IPv4 and IPv6 traffic. With many cloud providers also beginning to offer dual-stack Kubernetes clusters, it's easier than ever to run services that function across both address types. Istio introduced dual-stack as an experimental feature in version 1.17, promoted it to [Alpha](https://istio.io/latest/news/releases/1.24.x/announcing-1.24/change-notes/) in version 1.24, and to [Beta](https://istio.io/latest/news/releases/1.28.x/announcing-1.28/change-notes/) in version 1.28. With Istio in dual-stack mode, services can communicate over both IPv4 and IPv6 endpoints, which helps organizations transition to IPv6 while still maintaining compatibility with their existing IPv4 infrastructure.
+
+When Kubernetes is configured for dual-stack, it automatically assigns an IPv4 and an IPv6 address to each pod, enabling them to communicate over both IP families. For services, however, you can control how they behave using the `ipFamilyPolicy` setting.
+
+Service.Spec.ipFamilyPolicy can take the following values:
+
+- `SingleStack`: Only one IP family is configured for the service, which can be either IPv4 or IPv6.
+- `PreferDualStack`: Both IPv4 and IPv6 cluster IPs are assigned to the Service when dual-stack is enabled. However, if dual-stack is not enabled or supported, it falls back to singleStack behavior.
+- `RequireDualStack`: The service will be created only if both IPv4 and IPv6 addresses can be assigned.
+
+This allows you to specify the type of service, providing flexibility in managing your network configuration. For more details, you can refer to the Kubernetes [documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/installing/dual-stack/install-mesh-in-dual-stack-mode.mdx
+++ b/docs/en/installing/dual-stack/install-mesh-in-dual-stack-mode.mdx
@@ -1,0 +1,212 @@
+---
+weight: 10
+---
+
+# Installing a mesh in dual-stack mode
+
+Install Istio with dual-stack networking support to enable both IPv4 and IPv6 connectivity within your service mesh.
+
+**Prerequisites**
+
+- Kubernetes configured with dual-stack support.
+- The Alauda Container Platform Networking for Multus plugin must be installed, and kube-ovn must be v4.1.5 or later.
+- You have installed the Alauda Service Mesh v2 Operator on your cluster.
+
+## Procedure
+
+<Steps>
+  ### Install IstioCNI
+
+  Install the `IstioCNI` resource by running the following command:
+
+  ```bash
+  kubectl create namespace istio-cni
+  cat <<EOF | kubectl apply -f -
+  apiVersion: sailoperator.io/v1
+  kind: IstioCNI
+  metadata:
+    name: default
+  spec:
+    namespace: istio-cni
+    values:
+      cni:
+        cniConfDir: /etc/cni/multus/net.d # /etc/cni/net.d in ACP 4.0
+        excludeNamespaces:
+          - istio-cni
+          - kube-system
+  EOF
+  ```
+
+  ### Install Istio with dual-stack configuration
+
+  1. Create an `Istio` resource with dual-stack configuration by running the following command:
+
+     ```bash
+     kubectl create namespace istio-system
+     kubectl label namespace istio-system cpaas.io/project=cpaas-system
+     cat <<EOF | kubectl apply -f -
+     apiVersion: sailoperator.io/v1
+     kind: Istio
+     metadata:
+       name: default
+     spec:
+       namespace: istio-system
+       values:
+         meshConfig:
+           defaultConfig:
+             proxyMetadata:
+               ISTIO_DUAL_STACK: "true"
+         pilot:
+           ipFamilyPolicy: RequireDualStack
+           env:
+             ISTIO_DUAL_STACK: "true"
+     EOF
+     ```
+
+  2. Wait for the control plane to return the `Ready` status condition by running the following command:
+
+     ```bash
+     kubectl wait --for condition=Ready istio/default --timeout=3m
+     ```
+
+</Steps>
+
+## Verifying a dual-stack mesh
+
+To confirm that your dual-stack mesh is functioning correctly, you will deploy sample applications with different IP family configurations. The goal is to verify that the mesh can handle IPv4, IPv6, and dual-stack services.
+
+**Procedure**
+
+<Steps>
+
+### Create namespaces for the sample applications
+
+Create the following namespaces, each hosting the `tcp-echo` service with a specific IP configuration:
+
+- `dual-stack`: hosts a `tcp-echo` service that listens on both IPv4 and IPv6 addresses.
+- `ipv4`: hosts a `tcp-echo` service listening only on IPv4 addresses.
+- `ipv6`: hosts a `tcp-echo` service listening only on IPv6 addresses.
+- `sleep`: hosts the client application for sending test requests.
+
+   ```bash
+   kubectl create namespace dual-stack
+   kubectl create namespace ipv4
+   kubectl create namespace ipv6
+   kubectl create namespace sleep
+   ```
+
+### Enable sidecar injection for the namespaces
+
+Label the namespaces to enable automatic Istio sidecar injection by running the following command:
+
+```bash
+kubectl label namespace dual-stack istio-injection=enabled
+kubectl label namespace ipv4 istio-injection=enabled
+kubectl label namespace ipv6 istio-injection=enabled
+kubectl label namespace sleep istio-injection=enabled
+```
+
+### Deploy the sample applications
+
+1. Deploy the `tcp-echo` application with dual-stack configuration:
+
+   ```bash
+   kubectl apply -n dual-stack -f https://raw.githubusercontent.com/alauda-mesh/istio/istio-1.28/samples/tcp-echo/tcp-echo-dual-stack.yaml
+   ```
+
+2. Deploy the `tcp-echo` application with IPv4-only configuration:
+
+   ```bash
+   kubectl apply -n ipv4 -f https://raw.githubusercontent.com/alauda-mesh/istio/istio-1.28/samples/tcp-echo/tcp-echo-ipv4.yaml
+   ```
+
+3. Deploy the `tcp-echo` application with IPv6-only configuration:
+
+   ```bash
+   kubectl apply -n ipv6 -f https://raw.githubusercontent.com/alauda-mesh/istio/istio-1.28/samples/tcp-echo/tcp-echo-ipv6.yaml
+   ```
+
+4. Deploy the `sleep` application, which will act as a client for sending test requests:
+
+   ```bash
+   kubectl apply -n sleep -f https://raw.githubusercontent.com/alauda-mesh/istio/istio-1.28/samples/sleep/sleep.yaml
+   ```
+
+5. Wait for all deployments to become available:
+
+   ```bash
+   kubectl wait --for=condition=Ready pod -n dual-stack -l app=tcp-echo --timeout=60s
+   kubectl wait --for=condition=Ready pod -n ipv4 -l app=tcp-echo --timeout=60s
+   kubectl wait --for=condition=Ready pod -n ipv6 -l app=tcp-echo --timeout=60s
+   kubectl wait --for=condition=Ready pod -n sleep -l app=sleep --timeout=60s
+   ```
+
+### Verify the dual-stack service configuration
+
+Confirm that the `tcp-echo` service in the `dual-stack` namespace is configured with `ipFamilyPolicy` of `RequireDualStack` by running the following command:
+
+```bash
+kubectl get service tcp-echo -n dual-stack -o=jsonpath='{.spec.ipFamilyPolicy}'
+```
+
+**Example output**
+
+```bash
+RequireDualStack
+```
+
+### Verify connectivity to dual-stack services
+
+Send a test request from the `sleep` pod to the dual-stack `tcp-echo` service by running the following command:
+
+```bash
+kubectl exec -n sleep deploy/sleep -- sh -c "echo dualstack | nc tcp-echo.dual-stack 9000"
+```
+
+**Example output**
+
+```bash
+tcp-echo-xxx: hello dualstack
+```
+
+### Verify connectivity to IPv4 and IPv6 services
+
+1. Send a test request to the IPv4-only `tcp-echo` service:
+
+   ```bash
+   kubectl exec -n sleep deploy/sleep -- sh -c "echo ipv4 | nc tcp-echo.ipv4 9000"
+   ```
+
+   **Example output**
+
+   ```bash
+   tcp-echo-xxx: hello ipv4
+   ```
+
+2. Send a test request to the IPv6-only `tcp-echo` service:
+
+   ```bash
+   kubectl exec -n sleep deploy/sleep -- sh -c "echo ipv6 | nc tcp-echo.ipv6 9000"
+   ```
+
+   **Example output**
+
+   ```bash
+   tcp-echo-xxx: hello ipv6
+   ```
+
+</Steps>
+
+## Removing a dual-stack mesh from a development environment
+
+After completing your verification and experimentation, you should remove the dual-stack configuration to clean up the development environment and release resources.
+
+**Procedure**
+
+Execute the following commands to remove all Istio components and the sample applications:
+
+```bash
+kubectl delete istio/default istiocni/default
+kubectl delete ns/dual-stack ns/ipv4 ns/ipv6 ns/sleep
+kubectl delete ns/istio-system ns/istio-cni
+```

--- a/docs/en/installing/installing-service-mesh/application-deployment/deploying-the-bookinfo-application.mdx
+++ b/docs/en/installing/installing-service-mesh/application-deployment/deploying-the-bookinfo-application.mdx
@@ -230,7 +230,8 @@ kubectl -n bookinfo port-forward svc/istio-ingressgateway 9080:80
 ```
 
 - If you run the command locally on your workstation, open `http://localhost:9080/productpage` in your browser.  
-- If you ran the command on a remote host and used `--address 0.0.0.0`, replace `localhost` with the remote host's IP or hostname (for example `http://<REMOTE_HOST_IP>:9080/productpage`)
+- If you ran the command on a remote **IPv4** host and used `--address "0.0.0.0"`, replace `localhost` with the remote host's IP or hostname (for example `http://<REMOTE_HOST_IP>:9080/productpage`)
+- If you ran the command on a remote **IPv6** host and used `--address "::"`, replace `localhost` with the remote host's IP or hostname (for example `http://[<REMOTE_HOST_IP>]:9080/productpage`)
 
 When you refresh the page several times, you should see different versions of reviews shown in `productpage`, presented in a round robin style (red stars, black stars, no stars), since we haven't yet used Istio to control the version routing.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation covering Kubernetes dual-stack support, including Istio installation procedures in dual-stack mode with prerequisites, step-by-step setup instructions, verification steps, and connectivity testing.
  * Updated Bookinfo application deployment guide with separate remote access instructions for IPv4 and IPv6 configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->