### PR TITLE
feat: istio and kube gateway api add infra nodes info 

### DIFF
--- a/docs/en/gateways/directing-outbound-traffic/routing-egress-traffic-via-k8s-gateway-api.mdx
+++ b/docs/en/gateways/directing-outbound-traffic/routing-egress-traffic-via-k8s-gateway-api.mdx
@@ -117,6 +117,68 @@ This section describes how to use the Kubernetes Gateway API to route outbound H
     httpbin-egress-gateway   istio   httpbin-egress-gateway-istio.egress-gateway.svc.cluster.local   True         68s
     ```
 
+4.  *Optional* : Deploy the gateway to <ExternalSiteLink name="acp" href="/configure/clusters/acp-node-planning.html" children="Infra Nodes" />:
+
+    <details>
+      <summary>Click to expand</summary>
+
+      <Directive type="info" title="Prerequisites">
+      Alauda Container Platform 4.2.0 or later, or upgrade Gateway API CRDs to the latest version.
+      </Directive>
+      
+      a. Create a ConfigMap named `asm-kube-gateway-options` in the same namespace where you plan to deploy your Gateway:
+
+        ```yaml
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: asm-kube-gateway-options  # [!code callout]
+          namespace: egress-gateway  # [!code callout]
+        data:  # [!code callout]
+          deployment: |
+            spec:
+              template:
+                spec:
+                  nodeSelector:
+                    node-role.kubernetes.io/infra: ""
+                  tolerations:
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/infra
+                      value: reserved
+                      operator: Equal
+        ```
+
+        <Callouts>
+          1.  Specifies the configmap's name.
+          2.  Specifies the configmap's namespace same as the gateway.
+          3.  Sets node selectors and tolerations to schedule the gateway pods on Infra Nodes.
+        </Callouts>
+
+      b. Reference the ConfigMap in your Gateway resource by adding the `infrastructure.parametersRef` field:
+
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: Gateway
+        metadata:
+          name: httpbin-egress-gateway  # [!code callout]
+          namespace: egress-gateway  # [!code callout]
+        spec:
+          # Add the following infrastructure configuration to your Gateway CR
+          infrastructure:
+            parametersRef:
+              group: ""
+              kind: ConfigMap
+              name: asm-kube-gateway-options
+          # ... rest of your Gateway configuration
+        ```
+
+        <Callouts>
+          1.  Specifies the gateway's name.
+          2.  Specifies the gateway's namespace.
+        </Callouts>
+
+    </details>
+
 ## Verification
 
 1.  Create a namespace named `curl` by executing the following command:

--- a/docs/en/gateways/directing-traffic-into-the-mesh/exposing-a-service-via-k8s-gateway-api.mdx
+++ b/docs/en/gateways/directing-traffic-into-the-mesh/exposing-a-service-via-k8s-gateway-api.mdx
@@ -114,6 +114,68 @@ You can use the Kubernetes Gateway API to create `Gateway` and `HTTPRoute` resou
     kubectl wait --for=condition=programmed gtw httpbin-gateway -n httpbin
     ```
 
+8.  *Optional* : Deploy the gateway to <ExternalSiteLink name="acp" href="/configure/clusters/acp-node-planning.html" children="Infra Nodes" />:
+
+    <details>
+      <summary>Click to expand</summary>
+
+      <Directive type="info" title="Prerequisites">
+      Alauda Container Platform 4.2.0 or later, or upgrade Gateway API CRDs to the latest version.
+      </Directive>
+      
+      a. Create a ConfigMap named `asm-kube-gateway-options` in the same namespace where you plan to deploy your Gateway:
+
+        ```yaml
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: asm-kube-gateway-options  # [!code callout]
+          namespace: httpbin  # [!code callout]
+        data:  # [!code callout]
+          deployment: |
+            spec:
+              template:
+                spec:
+                  nodeSelector:
+                    node-role.kubernetes.io/infra: ""
+                  tolerations:
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/infra
+                      value: reserved
+                      operator: Equal
+        ```
+
+        <Callouts>
+          1.  Specifies the configmap's name.
+          2.  Specifies the configmap's namespace same as the gateway.
+          3.  Sets node selectors and tolerations to schedule the gateway pods on Infra Nodes.
+        </Callouts>
+
+      b. Reference the ConfigMap in your Gateway resource by adding the `infrastructure.parametersRef` field:
+
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: Gateway
+        metadata:
+          name: httpbin-gateway  # [!code callout]
+          namespace: httpbin  # [!code callout]
+        spec:
+          # Add the following infrastructure configuration to your Gateway CR
+          infrastructure:
+            parametersRef:
+              group: ""
+              kind: ConfigMap
+              name: asm-kube-gateway-options
+          # ... rest of your Gateway configuration
+        ```
+
+        <Callouts>
+          1.  Specifies the gateway's name.
+          2.  Specifies the gateway's namespace.
+        </Callouts>
+
+    </details>
+
 ## Verification
 
 1.  Create a namespace for a `curl` client by executing this command:

--- a/docs/en/gateways/gateway-installation/about-gateway-injection.mdx
+++ b/docs/en/gateways/gateway-installation/about-gateway-injection.mdx
@@ -26,6 +26,10 @@ Skip this section if your kernel version is 4.11 or later.
 
 #### Procedure
 
+:::info
+On some operating systems (e.g., CentOS 7) with older Linux kernels, gateways may not be able to listen on ports below 1024. It is recommended to configure your gateway to use ports above 1024 to avoid privilege requirements. If you must use privileged ports (below 1024), configure the `gateway-injection-template.txt` to either add the `NET_BIND_SERVICE` capability to the gateway's istio-proxy container or run the gateway as the root user by updating the container security context settings.
+:::
+
 1. Create a YAML file named `gateway-injection-template.txt` that contains the default injection template for gateways.
 
    <details>
@@ -334,7 +338,7 @@ Skip this section if your kernel version is 4.11 or later.
 #### Procedure
 
 :::info
-On some operating systems (e.g., CentOS 7) with older Linux kernels, gateways may not be able to listen on ports below 1024. It is recommended to configure your gateway to use ports above 1024 to avoid privilege requirements. If you must use privileged ports (below 1024), configure the gateway to either add the `NET_BIND_SERVICE` capability to the gateway container or run the gateway as the root user by creating a ConfigMap with custom container security context settings.
+On some operating systems (e.g., CentOS 7) with older Linux kernels, gateways may not be able to listen on ports below 1024. It is recommended to configure your gateway to use ports above 1024 to avoid privilege requirements. If you must use privileged ports (below 1024), configure the gateway to either add the `NET_BIND_SERVICE` capability to the gateway's istio-proxy container or run the gateway as the root user by creating a ConfigMap with custom container security context settings.
 :::
 
 1. Create a ConfigMap named `asm-kube-gateway-options` in the same namespace where you plan to deploy your Gateway:

--- a/docs/en/gateways/gateway-installation/installing-a-gateway-via-injection.mdx
+++ b/docs/en/gateways/gateway-installation/installing-a-gateway-via-injection.mdx
@@ -115,6 +115,13 @@ The following procedure applies to both ingress and egress gateway deployments.
                  cpu: 100m
                  memory: 128Mi
          serviceAccountName: secret-reader  # [!code callout]
+         nodeSelector:  # [!code callout]
+           node-role.kubernetes.io/infra: ""
+         tolerations:  # [!code callout]
+           - effect: NoSchedule
+             key: node-role.kubernetes.io/infra
+             value: reserved
+             operator: Equal
    ```
 
    <Callouts>
@@ -125,6 +132,8 @@ The following procedure applies to both ingress and egress gateway deployments.
         If the name of the Istio resource is not default you must use the `istio.io/rev: <istio_revision>` label instead, where the revision represents the active revision of the Istio resource.
      4. Sets the image field to `auto` so that the image automatically updates each time the pod starts.
      5. Sets the `serviceAccountName` to the name of the `ServiceAccount` created previously.
+     6. (Optional) Sets node selectors to schedule the gateway pods on <ExternalSiteLink name="acp" href="/configure/clusters/acp-node-planning.html" children="Infra Nodes" />.
+     7. (Optional) Sets tolerations to allow the gateway pods to be scheduled on <ExternalSiteLink name="acp" href="/configure/clusters/acp-node-planning.html" children="Infra Nodes" />.
    </Callouts>
 
 6. Apply the YAML file by running the following command:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional deployment guidance for running gateways on infrastructure nodes with ConfigMap-based nodeSelector and toleration configuration.
  * Added instructions for handling privileged ports on older Linux kernels with NET_BIND_SERVICE capability configuration options.
  * Expanded gateway installation documentation with node scheduling constraint and toleration examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->