### PR TITLE
chore: update mesh-v2-test-suite OpenTelemetry Images

### DIFF
--- a/charts/mesh-v2-test-suite/Chart.yaml
+++ b/charts/mesh-v2-test-suite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mesh-v2-test-suite
 description: Mesh v2 测试套件，将一组服务网格测试镜像随 ACP 集群插件预置到集群
 type: application
-version: v1.0.0
+version: v1.0.1
 appVersion: "1.0.0"

--- a/charts/mesh-v2-test-suite/module-plugin.yaml
+++ b/charts/mesh-v2-test-suite/module-plugin.yaml
@@ -16,7 +16,7 @@ spec:
   - chartVersions:
     - name: asm/mesh-v2-test-suite
       releaseName: mesh-v2-test-suite
-      version: v1.0.0
+      version: v1.0.1
     name: mesh-v2-test-suite
   deleteable: true
   description:

--- a/charts/mesh-v2-test-suite/values.yaml
+++ b/charts/mesh-v2-test-suite/values.yaml
@@ -67,9 +67,14 @@ global:
       tag: "v4.0.1"
       support_arm: true
       thirdparty: false
-    # OpenTelemetry Auto-instrumentation Images
+    # OpenTelemetry Images
     autoinstrumentation-java:
-      repository: asm/autoinstrumentation-java
+      repository: asm/opentelemetry-operator/autoinstrumentation-java
       tag: "2.26.1"
+      support_arm: true
+      thirdparty: true
+    telemetrygen:
+      repository: asm/opentelemetry-collector-contrib/telemetrygen
+      tag: "latest"
       support_arm: true
       thirdparty: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped mesh-v2-test-suite chart version to v1.0.1
  * Updated OpenTelemetry image configurations with new telemetrygen image support
  * Updated autoinstrumentation image repository paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->