### PR TITLE
Feat: release notes for v2.1.2

### DIFF
--- a/docs/en/about/lifecycle-policy/alauda-build-of-kiali.mdx
+++ b/docs/en/about/lifecycle-policy/alauda-build-of-kiali.mdx
@@ -12,6 +12,7 @@ Below is the life cycle schedule for released versions of the `Alauda Build of K
 | -------- | ------------- | -------------- |
 | v2.11.z  | 2025-08-20    | 2027-02-20     |
 | v2.17.z  | 2026-01-05    | 2027-07-05     |
+| v2.22.z  | 2026-05-11    | 2027-11-11     |
 
 ## Release Policy
 

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1-known-issues.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1-known-issues.mdx
@@ -8,9 +8,17 @@ This section documents known issues and limitations that affect Alauda Service M
 
 ## Ambient mode is not supported on FIPS-enabled clusters
 
+:::info
+This issue has been resolved in Alauda Service Mesh v2.1.2. Upgrade Istio to v1.28.6 to apply the fix.
+:::
+
 Clusters configured to enforce Federal Information Processing Standards (FIPS) are currently incompatible with Istio ambient mode. If your environment requires FIPS compliance, you should continue to deploy the service mesh using sidecar mode. Ambient mode support for FIPS-enabled clusters is expected to be addressed in a future release.
 
 ## Kiali tracing integration is not functional in ambient mode
+
+:::info
+This issue has been resolved in Alauda Service Mesh v2.1.2. Upgrade Kiali to v2.22 to apply the fix.
+:::
 
 When using Istio ambient mode, Kiali may fail to query distributed traces and generate incorrect links to the tracing backend (such as Jaeger). This occurs because the service name used for trace lookup does not match the actual service name recorded by the tracing collector in ambient mode deployments.
 
@@ -23,6 +31,10 @@ The root cause is a change in how Istio ambient mode generates traces. In ambien
 **Reference:** [kiali/kiali#9158](https://github.com/kiali/kiali/issues/9158)
 
 ## Multi-cluster service mesh does not support IPv6 load balancer IP
+
+:::info
+This issue has been resolved in Alauda Service Mesh v2.1.2. Upgrade Istio to v1.28.6 to apply the fix.
+:::
 
 In multi-cluster (primary/remote) deployments, the Istio Helm chart only recognizes IPv4 addresses for the `global.remotePilotAddress` configuration parameter. If an IPv6 address is provided (such as `2001:db8::1`), the `EndpointSlice` template in `istio-discovery` fails to render correctly, causing the Istio installation to fail.
 

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
@@ -28,11 +28,11 @@ Alauda Service Mesh v2.1 is built on the [Istio](https://istio.io/) project and 
     - **AI integration**: AI Chatbot Widget and MCP integration delivered as a developer preview, introducing AI-assisted operations alongside community AI and Agent contribution guidelines.
     - **Performance**: Pre-computed health status with a configurable cache (5 minutes by default) for faster Overview and List pages; background traffic-graph refresh and caching for quicker re-renders, plus improved client-side rendering for graphs with many service nodes.
     - **Authentication & SSO**: Explicit OIDC configuration when `.well-known/openid-configuration` endpoints are restricted, OpenID Authorization Code Flow with PKCE support, and SPIRE integration in the UI.
-    - **TLS & certificates**: Auto-rotated certificates for external service connectivity (Prometheus, tracing) and platform TLS profile enforcement via OpenShift-aware auto mode.
-    - **UI modernization**: Upgraded to TypeScript 5, migrated to PatternFly 6 (including OSSMC, Wizard, and date-picker components), and replaced the legacy message center with a modern notification center.
+    - **TLS & certificates**: Auto-rotated certificates for external service connectivity (Prometheus, tracing).
+    - **UI modernization**: Upgraded to TypeScript 5, migrated to PatternFly 6 (including Wizard and date-picker components), and replaced the legacy message center with a modern notification center.
     - **Mesh page**: Improved topology visualization for environments with many control planes, refined data-plane side-panel validations, and enhanced masthead status with better multi-mesh handling.
     - **Gateway API**: Added support for Kubernetes Gateway API v1.4.0.
-    - **Tracing & observability**: Perses Dashboard `openshift` URL format support, Netobserv navigation integrated into the OSSMC traffic-graph side-panel, and a `use_waypoint_name` option to correct service names in Jaeger links.
+    - **Tracing & observability**: Added a `use_waypoint_name` configuration option under `external_services.tracing` to correct service names in Jaeger links for ambient mode.
     - **Operator & deployment**: Custom `initContainers` in the Kiali CR, Helm chart support for `cluster_wide_access=false`, operator sidecar usage extension, and NetworkPolicies for OLM-installed operators.
 - References
     - [Kiali 2.18.0 Release Notes](https://kiali.io/news/release-notes/#2180)

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
@@ -6,11 +6,29 @@ weight: 9000
 
 Alauda Service Mesh v2.1 is built on the [Istio](https://istio.io/) project and is installed using a new Istio Operator derived from the [Sail Operator](https://github.com/istio-ecosystem/sail-operator) (hosted in the **istio-ecosystem** GitHub organization). The Operator provides an expanded set of custom resource definitions (CRDs) to manage Istio components.
 
+## Alauda Service Mesh v2.1.2
+
+### Supported component versions
+
+- `Istio` version: v1.26.3, v1.28.1 , v1.28.3 and v1.28.6
+    - Istio 1.28 [supports Kubernetes](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) 1.30, 1.31, 1.32, 1.33, 1.34
+    - Istio 1.26 [supports Kubernetes](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) 1.29, 1.30, 1.31, 1.32, 1.33
+- `Kiali operator` version: v2.22.2
+
+### Istio Features
+
+- Updated Istio to version 1.28.6.
+- Fixed Common Vulnerabilities and Exposures (CVEs).
+
+### Kiali Features
+
+- Fixed Common Vulnerabilities and Exposures (CVEs).
+
 ## Alauda Service Mesh v2.1.1
 
 ### Supported component versions
 
-- `Istio` version: v1.26.3, v1.28.1 and v1.28.1
+- `Istio` version: v1.26.3, v1.28.1 and v1.28.3
     - Istio 1.28 [supports Kubernetes](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) 1.30, 1.31, 1.32, 1.33, 1.34
     - Istio 1.26 [supports Kubernetes](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) 1.29, 1.30, 1.31, 1.32, 1.33
 - `Kiali operator` version: v2.17.1

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
@@ -22,7 +22,22 @@ Alauda Service Mesh v2.1 is built on the [Istio](https://istio.io/) project and 
 
 ### Kiali Features
 
-- Fixed Common Vulnerabilities and Exposures (CVEs).
+- Updated Kiali to version 2.22.
+    - **AI integration**: AI Chatbot Widget and MCP integration delivered as a developer preview, introducing AI-assisted operations alongside community AI and Agent contribution guidelines.
+    - **Performance**: Pre-computed health status with a configurable cache (5 minutes by default) for faster Overview and List pages; background traffic-graph refresh and caching for quicker re-renders, plus improved client-side rendering for graphs with many service nodes.
+    - **Authentication & SSO**: Explicit OIDC configuration when `.well-known/openid-configuration` endpoints are restricted, OpenID Authorization Code Flow with PKCE support, and SPIRE integration in the UI.
+    - **TLS & certificates**: Auto-rotated certificates for external service connectivity (Prometheus, tracing) and platform TLS profile enforcement via OpenShift-aware auto mode.
+    - **UI modernization**: Upgraded to TypeScript 5, migrated to PatternFly 6 (including OSSMC, Wizard, and date-picker components), and replaced the legacy message center with a modern notification center.
+    - **Mesh page**: Improved topology visualization for environments with many control planes, refined data-plane side-panel validations, and enhanced masthead status with better multi-mesh handling.
+    - **Gateway API**: Added support for Kubernetes Gateway API v1.4.0.
+    - **Tracing & observability**: Perses Dashboard `openshift` URL format support, Netobserv navigation integrated into the OSSMC traffic-graph side-panel, and a `use_waypoint_name` option to correct service names in Jaeger links.
+    - **Operator & deployment**: Custom `initContainers` in the Kiali CR, Helm chart support for `cluster_wide_access=false`, operator sidecar usage extension, and NetworkPolicies for OLM-installed operators.
+- References
+    - [Kiali 2.18.0 Release Notes](https://kiali.io/news/release-notes/#2180)
+    - [Kiali 2.19.0 Release Notes](https://kiali.io/news/release-notes/#2190)
+    - [Kiali 2.20.0 Release Notes](https://kiali.io/news/release-notes/#2200)
+    - [Kiali 2.21.0 Release Notes](https://kiali.io/news/release-notes/#2210)
+    - [Kiali 2.22.0 Release Notes](https://kiali.io/news/release-notes/#2220)
 
 ## Alauda Service Mesh v2.1.1
 

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
@@ -18,12 +18,13 @@ Alauda Service Mesh v2.1 is built on the [Istio](https://istio.io/) project and 
 ### Istio Features
 
 - Updated Istio to version 1.28.6.
-- Fixed Common Vulnerabilities and Exposures (CVEs).
 - Fixed Istio ambient mode incompatibility on FIPS-enabled clusters, allowing ambient mode to be deployed in FIPS-compliant environments.
 - Fixed multi-cluster `global.remotePilotAddress` rendering failure when configured with an IPv6 address, restoring IPv6 load balancer support for primary/remote deployments.
+- Fixed Common Vulnerabilities and Exposures (CVEs).
 
 ### Kiali Features
 
+- Fixed Common Vulnerabilities and Exposures (CVEs).
 - Updated Kiali to version 2.22.
     - **AI integration**: AI Chatbot Widget and MCP integration delivered as a developer preview, introducing AI-assisted operations alongside community AI and Agent contribution guidelines.
     - **Performance**: Pre-computed health status with a configurable cache (5 minutes by default) for faster Overview and List pages; background traffic-graph refresh and caching for quicker re-renders, plus improved client-side rendering for graphs with many service nodes.

--- a/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
+++ b/docs/en/about/release-notes/alauda-service-mesh-v2.1.mdx
@@ -19,6 +19,8 @@ Alauda Service Mesh v2.1 is built on the [Istio](https://istio.io/) project and 
 
 - Updated Istio to version 1.28.6.
 - Fixed Common Vulnerabilities and Exposures (CVEs).
+- Fixed Istio ambient mode incompatibility on FIPS-enabled clusters, allowing ambient mode to be deployed in FIPS-compliant environments.
+- Fixed multi-cluster `global.remotePilotAddress` rendering failure when configured with an IPv6 address, restoring IPv6 load balancer support for primary/remote deployments.
 
 ### Kiali Features
 

--- a/docs/en/installing/ambient-mode/runme-test_deploying-ambient-bookinfo.sh
+++ b/docs/en/installing/ambient-mode/runme-test_deploying-ambient-bookinfo.sh
@@ -119,6 +119,20 @@ EOF
     fi
     log_success "ZTunnel 代理验证通过"
 
+    # 10. (可选) 生成请求流量
+    if [ "${AUTO_GEN_BOOKINFO_TRAFFIC:-false}" == "true" ]; then
+        log_info "步骤 10: 生成请求流量"
+        local ratings_pod
+        ratings_pod=$(kubectl get pod -l app=ratings -n bookinfo -o jsonpath='{.items[0].metadata.name}')
+        if [ -n "$ratings_pod" ]; then
+            log_info "在 ratings pod ($ratings_pod) 中启动流量生成..."
+            kubectl exec "$ratings_pod" -c ratings -n bookinfo -- bash -lc "(while true; do curl -sS productpage:9080/productpage >/dev/null; sleep 9.9; done) >/dev/null 2>&1 & disown"
+            log_success "流量生成已启动"
+        else
+            log_warn "未找到 ratings pod, 跳过流量生成"
+        fi
+    fi
+
     log_success "=========================================="
     log_success "Ambient 模式 Bookinfo 应用部署测试完成，所有验证通过！"
     log_success "=========================================="

--- a/docs/en/installing/installing-service-mesh/install-mesh.mdx
+++ b/docs/en/installing/installing-service-mesh/install-mesh.mdx
@@ -34,9 +34,9 @@ If the update strategy of the `Istio` resource is set to `RevisionBased`, the Op
 - You are logged in to the Alauda Container Platform web console as **cluster-admin**.
 - The Alauda Container Platform Networking for Multus plugin must be installed, and kube-ovn must be v4.1.5 or later.
 
-:::warning
-The Alauda Container Platform Networking for Multus plugin must be installed **before** installing the Alauda Service Mesh v2 Operator. If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
-:::
+  :::danger The Multus plugin must be installed before installing the Alauda Service Mesh v2 Operator.
+  If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
+  :::
 
 **Procedure**
 
@@ -63,9 +63,9 @@ Verify that the Operator installation status is reported as `Succeeded` in the *
 - An active ACP CLI (`kubectl`) session by a cluster administrator with the `cluster-admin` role.
 - The Alauda Container Platform Networking for Multus plugin must be installed, and kube-ovn must be v4.1.5 or later.
 
-:::warning
-The Alauda Container Platform Networking for Multus plugin must be installed **before** installing the Alauda Service Mesh v2 Operator. If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
-:::
+  :::danger The Multus plugin must be installed before installing the Alauda Service Mesh v2 Operator.
+  If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
+  :::
 
 **Procedure**
 

--- a/docs/en/installing/installing-service-mesh/install-mesh.mdx
+++ b/docs/en/installing/installing-service-mesh/install-mesh.mdx
@@ -34,6 +34,10 @@ If the update strategy of the `Istio` resource is set to `RevisionBased`, the Op
 - You are logged in to the Alauda Container Platform web console as **cluster-admin**.
 - The Alauda Container Platform Networking for Multus plugin must be installed, and kube-ovn must be v4.1.5 or later.
 
+:::warning
+The Alauda Container Platform Networking for Multus plugin must be installed **before** installing the Alauda Service Mesh v2 Operator. If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
+:::
+
 **Procedure**
 
 1. In the Alauda Container Platform web console, navigate to **Administrator**.
@@ -58,6 +62,10 @@ Verify that the Operator installation status is reported as `Succeeded` in the *
 - The Alauda Service Mesh v2 must be uploaded.
 - An active ACP CLI (`kubectl`) session by a cluster administrator with the `cluster-admin` role.
 - The Alauda Container Platform Networking for Multus plugin must be installed, and kube-ovn must be v4.1.5 or later.
+
+:::warning
+The Alauda Container Platform Networking for Multus plugin must be installed **before** installing the Alauda Service Mesh v2 Operator. If the Operator is installed first, it must be uninstalled and reinstalled after the Multus plugin is in place.
+:::
 
 **Procedure**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kiali v2.22.z lifecycle entry with release and end-of-support dates.
  * Marked two known issues as resolved in v2.1.2 (requires Istio/Kiali upgrades).
  * Added release notes for Alauda Service Mesh v2.1.2 (Istio 1.28.6, Kiali 2.22) and corrected Istio info for v2.1.1.
  * Added installation warning that Multus must be installed before the operator.
  * Added optional Bookinfo traffic-generation step for ambient-mode testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/servicemesh2-docs/pull/101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->