### PR TITLE
docs(tracing): add optional discovery-selectors labeling step for jaeger-system

### DIFF
--- a/docs/en/integration/observability/distributed-tracing/config-with-service-mesh.mdx
+++ b/docs/en/integration/observability/distributed-tracing/config-with-service-mesh.mdx
@@ -35,6 +35,22 @@ The Jaeger v2 instance and the OpenTelemetry Collector are not service-mesh-spec
 **Procedure**
 
 <Steps>
+  ### (Optional) Label the `jaeger-system` namespace when the mesh uses discovery selectors
+
+  If the mesh limits the namespaces that the control plane watches by setting `discoverySelectors` on the `Istio` resource, the namespace that hosts the OpenTelemetry Collector (the `jaeger-system` namespace by default) must also match one of those selectors. Otherwise the control plane does not push the Collector Service to the sidecar proxies, and the proxies cannot export spans to it.
+
+  Apply the label that your `discoverySelectors` match to the `jaeger-system` namespace. For example, if the selectors match the `istio-discovery=enabled` label:
+
+  ```bash {name=mesh-tracing:label-jaeger-system-discovery}
+  kubectl label namespace jaeger-system istio-discovery=enabled
+  ```
+
+  :::note
+  Skip this step when the mesh does not use `discoverySelectors`. By default the control plane discovers every namespace, so the Collector is already visible and no extra label is required. Adding the label when discovery selectors are not in use has no effect.
+  :::
+
+  For more information about discovery selectors, see [Using `DiscoverySelectors`](../../../installing/installing-service-mesh/scoping-the-service-mesh/using-discovery-selectors.mdx) for sidecar mode, and [Discovery selectors in ambient mode](../../../installing/ambient-mode/ambient-discovery-selectors.mdx) for ambient mode.
+
   ### Update the `Istio` resource to enable tracing and define the OpenTelemetry tracing provider
 
   **Example: Enabling tracing via `meshConfig`**

--- a/docs/en/integration/observability/distributed-tracing/runme-test_config-with-service-mesh.sh
+++ b/docs/en/integration/observability/distributed-tracing/runme-test_config-with-service-mesh.sh
@@ -20,9 +20,24 @@ test_config_with_service_mesh() {
     log_info "开始网格调用链集成配置测试"
     log_info "=========================================="
 
-    # 步骤 1: Patch Istio resource，启用 tracing 并配置 OpenTelemetry extensionProvider
-    log_info "步骤 1: Patch Istio 启用 tracing 与 otel extensionProvider"
+    # 步骤 1: (可选) 为 jaeger-system 命名空间打服务发现标签。
+    # 仅当 Istio 启用了 discoverySelectors 时该步骤才必须；未启用时打标签也无副作用，
+    # 故测试统一执行。命名空间已带相同标签时 kubectl 以非 0 退出，属幂等场景需容忍。
+    log_info "步骤 1: (可选) 为 jaeger-system 命名空间打 istio-discovery 标签"
     local output
+    output=$(runme run mesh-tracing:label-jaeger-system-discovery 2>&1) || {
+        if __cmp_contains "$output" "already has a value"; then
+            log_warn "jaeger-system 已存在 istio-discovery 标签，跳过（幂等场景）"
+        else
+            log_error "为 jaeger-system 打服务发现标签失败"
+            log_error "输出: $output"
+            return 1
+        fi
+    }
+    log_success "jaeger-system 服务发现标签已就绪"
+
+    # 步骤 2: Patch Istio resource，启用 tracing 并配置 OpenTelemetry extensionProvider
+    log_info "步骤 2: Patch Istio 启用 tracing 与 otel extensionProvider"
     output=$(runme run mesh-tracing:patch-istio-config 2>&1) || {
         log_error "Patch Istio 失败"
         log_error "输出: $output"
@@ -34,8 +49,8 @@ test_config_with_service_mesh() {
     fi
     log_success "Istio tracing 配置已应用"
 
-    # 步骤 2: Patch Telemetry asm-default，启用 otel provider
-    log_info "步骤 2: Patch Telemetry asm-default 启用 otel provider"
+    # 步骤 3: Patch Telemetry asm-default，启用 otel provider
+    log_info "步骤 3: Patch Telemetry asm-default 启用 otel provider"
     output=$(runme run mesh-tracing:patch-telemetry-config 2>&1) || {
         log_error "Patch Telemetry 失败"
         log_error "输出: $output"


### PR DESCRIPTION
## What

Add an **optional** step to the *Configuring distributed tracing platform with Service Mesh* guide, placed before the **Update the `Istio` resource to enable tracing...** step.

When the mesh scopes its namespaces with `discoverySelectors`, the `jaeger-system` namespace that hosts the OpenTelemetry Collector must also match one of those selectors. Otherwise the control plane does not push the Collector Service to the sidecar proxies and spans cannot be exported.

Example:

```bash
kubectl label namespace jaeger-system istio-discovery=enabled
```

The step is safe to skip when discovery selectors are not in use — by default every namespace is discovered, and applying the label then has no effect.

## Changes

- **`config-with-service-mesh.mdx`** — new optional `<Steps>` entry with the label command, a `:::note` clarifying when it applies, and cross-links to:
  - `using-discovery-selectors.mdx` (sidecar mode)
  - `ambient-discovery-selectors.mdx` (ambient mode)
- **`runme-test_config-with-service-mesh.sh`** — cover the new `mesh-tracing:label-jaeger-system-discovery` block as step 1 (with idempotency tolerance, since `kubectl label` without `--overwrite` exits non-zero when the label already exists), and renumber the existing steps.

## Validation

Static only (no cluster/runme available locally):

- `bash -n` passes
- both internal link targets exist
- MDX code fences balanced
- runme block coverage remains 100% (5 named blocks ↔ 5 test references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional namespace labeling configuration step for Istio service mesh distributed tracing setups when using discovery selectors.
  * Included conditional guidance to skip this step when not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->